### PR TITLE
Adapts the delete AAS/SM testcases as per AAS Server v1.4.0

### DIFF
--- a/basyx.examples/pom.xml
+++ b/basyx.examples/pom.xml
@@ -118,7 +118,7 @@
 		<dependency>
 			<groupId>org.eclipse.basyx</groupId>
 			<artifactId>basyx.components.AASServer</artifactId>
-			<version>1.3.1</version>
+			<version>1.4.0</version>
 		</dependency>
 		
 		<!-- Adds additional classes of the BaSys SDK for tests -->

--- a/basyx.examples/src/test/java/org/eclipse/basyx/examples/snippets/manager/TestDeleteAAS.java
+++ b/basyx.examples/src/test/java/org/eclipse/basyx/examples/snippets/manager/TestDeleteAAS.java
@@ -32,6 +32,8 @@ import org.eclipse.basyx.submodel.metamodel.api.identifier.IdentifierType;
 import org.eclipse.basyx.submodel.metamodel.map.identifier.Identifier;
 import org.eclipse.basyx.vab.exception.provider.ResourceNotFoundException;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test for the DeleteAAS snippet
@@ -40,6 +42,8 @@ import org.junit.Test;
  *
  */
 public class TestDeleteAAS extends AbstractSnippetTest {
+	
+	private Logger logger = LoggerFactory.getLogger(TestDeleteAAS.class);
 
 	@Test
 	public void testDeleteAAS() {
@@ -48,7 +52,7 @@ public class TestDeleteAAS extends AbstractSnippetTest {
 		IIdentifier aasIdentifier = new Identifier(IdentifierType.CUSTOM, AAS_ID);
 
 		// Delete the AAS
-		DeleteAAS.deleteAAS(aasIdentifier, registryComponent.getRegistryPath());
+		deleteAas(aasIdentifier);
 
 		// Try to retrieve deleted AAS; should throw ResourceNotFoundException
 		try {
@@ -57,6 +61,14 @@ public class TestDeleteAAS extends AbstractSnippetTest {
 		} catch (ResourceNotFoundException e) {
 		}
 
+	}
+
+	private void deleteAas(IIdentifier aasIdentifier) {
+		try {
+			DeleteAAS.deleteAAS(aasIdentifier, registryComponent.getRegistryPath());
+		} catch (ResourceNotFoundException e) {	
+			logger.info("The AAS with id {} has already been unregistered from registry.", aasIdentifier.getId());
+		}
 	}
 
 }

--- a/basyx.examples/src/test/java/org/eclipse/basyx/examples/snippets/manager/TestDeleteSubmodelFromAAS.java
+++ b/basyx.examples/src/test/java/org/eclipse/basyx/examples/snippets/manager/TestDeleteSubmodelFromAAS.java
@@ -34,6 +34,8 @@ import org.eclipse.basyx.submodel.metamodel.api.identifier.IdentifierType;
 import org.eclipse.basyx.submodel.metamodel.map.identifier.Identifier;
 import org.eclipse.basyx.vab.exception.provider.ResourceNotFoundException;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test for the DeleteSubmodelFromAAS snippet
@@ -42,6 +44,8 @@ import org.junit.Test;
  *
  */
 public class TestDeleteSubmodelFromAAS extends AbstractSnippetTest {
+	
+	private Logger logger = LoggerFactory.getLogger(TestDeleteSubmodelFromAAS.class);
 
 	@Test
 	public void testDeleteSubmodel() {
@@ -51,7 +55,7 @@ public class TestDeleteSubmodelFromAAS extends AbstractSnippetTest {
 		IIdentifier smIdentifier = new Identifier(IdentifierType.CUSTOM, SM_ID);
 
 		// Delete the Submodel
-		DeleteSubmodelFromAAS.deleteSubmodelFromAAS(smIdentifier, aasIdentifier, registryComponent.getRegistryPath());
+		deleteSubmodel(aasIdentifier, smIdentifier);
 
 		// Get the AAS as ConnectedAAS
 		ConnectedAssetAdministrationShellManager manager = getManager();
@@ -64,6 +68,14 @@ public class TestDeleteSubmodelFromAAS extends AbstractSnippetTest {
 		} catch (ResourceNotFoundException e) {
 		}
 
+	}
+	
+	private void deleteSubmodel(IIdentifier aasIdentifier, IIdentifier smIdentifier) {
+		try {
+			DeleteSubmodelFromAAS.deleteSubmodelFromAAS(smIdentifier, aasIdentifier, registryComponent.getRegistryPath());
+		} catch (ResourceNotFoundException e) {	
+			logger.info("The Submodel with id {} has already been unregistered from registry.", smIdentifier.getId());
+		}
 	}
 
 }


### PR DESCRIPTION
The AAS server (v1.4.0) now unregisters the deleted AAS/SMs automatically from the registry, the deletion again would throw an exception.

This PR addresses this by adapting the corresponding TCs.

Signed-off-by: Mohammad Ghazanfar Ali Danish <ghazanfar.danish@iese.fraunhofer.de>